### PR TITLE
fix typo and use GET to verify-email

### DIFF
--- a/Controllers/AccountsController.cs
+++ b/Controllers/AccountsController.cs
@@ -63,7 +63,7 @@ public class AccountsController : BaseController
     }
 
     [AllowAnonymous]
-    [HttpPost("verify-email")]
+    [HttpGet("verify-email")]
     public IActionResult VerifyEmail(VerifyEmailRequest model)
     {
         _accountService.VerifyEmail(model.Token);

--- a/Services/AccountService.cs
+++ b/Services/AccountService.cs
@@ -377,7 +377,7 @@ public class AccountService : IAccountService
         {
             // origin exists if request sent from browser single page app (e.g. Angular or React)
             // so send link to verify via single page app
-            var verifyUrl = $"{origin}/account/verify-email?token={account.VerificationToken}";
+            var verifyUrl = $"{origin}/accounts/verify-email?token={account.VerificationToken}";
             message = $@"<p>Please click the below link to verify your email address:</p>
                             <p><a href=""{verifyUrl}"">{verifyUrl}</a></p>";
         }


### PR DESCRIPTION
Clicking the verify email link actually sends a GET request to the server, so the method should be GET instead of POST.

Also fixed a typo.

Tested in my own environment and email verification works after applying those changes.